### PR TITLE
Fixed csv writing issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,8 @@ def frontEnd():                                           # creates the interfac
             try:
                 with open('remindersData.csv', 'a', newline = '') as file:
                         writer = csv.writer(file)
-                        writer.writerow([exportData])  # export data to csv
+                        #removed the square brackets around exportData, this prevented writing to the csv properly
+                        writer.writerow(exportData)  # export data to csv
                                                         # input coming from line 60
 
             except():


### PR DESCRIPTION
Made minor change removing the square brackets around exportData in write row, writerow can accept a list of comma seperated entries and recognises it as the elements for each cell, when the square brackets were around them it interpreted [exportData] as one cell entry so wrote it all to the first cell.